### PR TITLE
More robust healtcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ ENV MOUNTPOINT /mnt/nfs-1
 RUN apk add --no-cache --update nfs-utils && \
     rm /sbin/halt /sbin/poweroff /sbin/reboot
 
-HEALTHCHECK --interval=1s --timeout=5s \
-    CMD mountpoint -q $MOUNTPOINT || exit 1
+HEALTHCHECK --interval=1s --timeout=5s --start-period=60s  \
+    CMD mount -t nfs | grep "$SERVER:$SHARE" || exit 1
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
The old healtcheck only checks if the folder is a mountpoint. It doesn't check if the mount is really done. Furthermore set the start-period, [see](https://docs.docker.com/engine/reference/builder/#healthcheck).